### PR TITLE
Update style.css to solve too wide title column

### DIFF
--- a/server/index_handler.go
+++ b/server/index_handler.go
@@ -11,7 +11,7 @@ var index = `<!DOCTYPE html><html>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <title>GGG Tracker</title>
     <link rel="shortcut icon" href="static/favicon.ico" />
-    <link rel="stylesheet" type="text/css" href="static/style.css?v2" />
+    <link rel="stylesheet" type="text/css" href="static/style.css?v3" />
     <link rel="alternate" type="application/rss+xml" title="GGG Tracker Forum Feed" href="rss" />
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -200,7 +200,6 @@ td.icon img {
 td.title {
     max-width: 450px;
     overflow: hidden;
-    white-space: nowrap;
 }
 
 td.body {

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -197,6 +197,12 @@ td.icon img {
     transform: translate(-50%, -50%);
 }
 
+td.title {
+    max-width: 450px;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
 td.body {
     background-color: #262626;
     padding: 10px;


### PR DESCRIPTION
Solves too wide title column like in the case of https://www.pathofexile.com/forum/view-post/14987094
Also makes the title always on one line - nowrap, which keeps the line height always the same. You can reconsider this if you want to.