### PR TITLE
Update forum_indexer.go with additional GGG users

### DIFF
--- a/server/forum_indexer.go
+++ b/server/forum_indexer.go
@@ -55,7 +55,8 @@ func (indexer *ForumIndexer) run() {
 		"Rachel_GGG", "Rob_GGG", "Roman_GGG", "Sarah_GGG", "SarahB_GGG", "Tom_GGG", "Natalia_GGG",
 		"Jeff_GGG", "Lu_GGG", "JuliaS_GGG", "Alexander_GGG", "SamC_GGG", "AndrewE_GGG", "Kyle_GGG",
 		"Stacey_GGG", "Jatin_GGG", "Yolandi_GGG", "Community_Team",
-		"Dominic_GGG", "Nick_GGG", "Guy_GGG", "Ben_GGG", "BenH_GGG", "Nav_GGG",
+		"Dominic_GGG", "Nick_GGG", "Guy_GGG", "Ben_GGG", "BenH_GGG", "Nav_GGG", "Will_GGG", 
+		"Scott_GGG", "JC_GGG", "Dylan_GGG", "Chulainn_GGG", 
 	}
 
 	timezone := (*time.Location)(nil)


### PR DESCRIPTION
Added multiple GGG accounts to the forum tracker from this thread:

"Will_GGG", "Scott_GGG", "JC_GGG", "Dylan_GGG", "Chulainn_GGG", 

https://www.pathofexile.com/forum/view-thread/3323720/filter-account-type/staff/page/2

I don't have a local environment to test, but this is just a CSV update and should be low risk