### PR TITLE
Add optional filtering of help posts

### DIFF
--- a/server/activity_handler.go
+++ b/server/activity_handler.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"github.com/labstack/echo"
-	log "github.com/sirupsen/logrus"
 )
 
 type jsonResponseActivity struct {
@@ -17,7 +16,21 @@ type jsonResponse struct {
 
 func ActivityHandler(db Database) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		activity, next, err := fetchActivity(db, LocaleForRequest(c.Request()), c.QueryParam("next"), c.QueryParam("nohelp") == "true")
+		locale := LocaleForRequest(c.Request())
+		filter := func(a Activity) bool {
+			return true
+		}
+		if c.QueryParam("nohelp") == "true" {
+			filter = func(a Activity) bool {
+				if fp, ok := a.(*ForumPost); ok {
+					if fp.ForumId == locale.HelpForumId {
+						return false
+					}
+				}
+				return true
+			}
+		}
+		activity, next, err := db.Activity(locale, c.QueryParam("next"), 50, filter)
 		if err != nil {
 			return err
 		}
@@ -41,52 +54,4 @@ func ActivityHandler(db Database) echo.HandlerFunc {
 		}
 		return c.JSON(200, response)
 	}
-}
-
-const MinPageSize = 50
-const DbRequestSize = 50
-const MaxDbRequests = 10
-
-func fetchActivity(db Database, locale *Locale, start string, nohelp bool) ([]Activity, string, error) {
-	activity := []Activity{}
-	next := start
-	pred := func(a Activity) bool {
-		return true
-	}
-	if nohelp {
-		pred = func(a Activity) bool {
-			if fp, ok := a.(*ForumPost); ok {
-				if fp.ForumId == locale.HelpForumId {
-					return false
-				}
-			}
-			return true
-		}
-	}
-	for i := 0; i < MaxDbRequests && len(activity) < MinPageSize; i++ {
-		as, n, err := db.Activity(locale, next, DbRequestSize)
-		if err != nil {
-			return nil, "", err
-		}
-		next = n
-		if len(as) == 0 && n == "" {
-			log.Debug("end of activity db")
-			break
-		}
-		filtered := 0
-		for _, a := range as {
-			if pred(a) {
-				activity = append(activity, a)
-			} else {
-				filtered++
-			}
-		}
-		log.WithFields(log.Fields{
-			"count":    len(as),
-			"buffered": len(activity),
-			"filtered": filtered,
-			"next":     next,
-		}).Debug("processed activity batch")
-	}
-	return activity, next, nil
 }

--- a/server/bolt_database.go
+++ b/server/bolt_database.go
@@ -43,7 +43,7 @@ func (db *BoltDatabase) AddActivity(activity []Activity) error {
 	})
 }
 
-func (db *BoltDatabase) Activity(locale *Locale, start string, count int) ([]Activity, string, error) {
+func (db *BoltDatabase) Activity(locale *Locale, start string, count int, filter func(a Activity) bool) ([]Activity, string, error) {
 	ret := []Activity(nil)
 	next := ""
 	if err := db.db.View(func(tx *bolt.Tx) error {
@@ -66,7 +66,7 @@ func (db *BoltDatabase) Activity(locale *Locale, start string, count int) ([]Act
 			activity, err := unmarshalActivity(k, v)
 			if err != nil {
 				return err
-			} else if activity != nil && locale.ActivityFilter(activity) {
+			} else if activity != nil && locale.ActivityFilter(activity) && filter(activity) {
 				ret = append(ret, activity)
 				next = base64.RawURLEncoding.EncodeToString(k)
 			}

--- a/server/database.go
+++ b/server/database.go
@@ -17,7 +17,7 @@ const (
 
 type Database interface {
 	AddActivity(activity []Activity) error
-	Activity(locale *Locale, start string, count int) ([]Activity, string, error)
+	Activity(locale *Locale, start string, count int, filter func(a Activity) bool) ([]Activity, string, error)
 	Close() error
 }
 

--- a/server/database_test.go
+++ b/server/database_test.go
@@ -31,21 +31,23 @@ func testDatabase_ForumPosts(t *testing.T, db Database) {
 
 	db.AddActivity([]Activity{post1, post2})
 
-	posts, next, err := db.Activity(locale, "", 1)
+	all := func(a Activity) bool { return true }
+
+	posts, next, err := db.Activity(locale, "", 1, all)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(posts))
 	assert.Equal(t, post1.Id, posts[0].(*ForumPost).Id)
 	assert.Equal(t, post1.Poster, posts[0].(*ForumPost).Poster)
 	assert.Equal(t, post1.Time.Unix(), posts[0].(*ForumPost).Time.Unix())
 
-	posts, next, err = db.Activity(locale, next, 1)
+	posts, next, err = db.Activity(locale, next, 1, all)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(posts))
 	assert.Equal(t, post2.Id, posts[0].(*ForumPost).Id)
 	assert.Equal(t, post2.Poster, posts[0].(*ForumPost).Poster)
 	assert.Equal(t, post2.Time.Unix(), posts[0].(*ForumPost).Time.Unix())
 
-	posts, _, err = db.Activity(locale, next, 1)
+	posts, _, err = db.Activity(locale, next, 1, all)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(posts))
 }

--- a/server/dynamodb_database.go
+++ b/server/dynamodb_database.go
@@ -82,7 +82,7 @@ func (db *DynamoDBDatabase) AddActivity(activity []Activity) error {
 	return nil
 }
 
-func (db *DynamoDBDatabase) Activity(locale *Locale, start string, count int) ([]Activity, string, error) {
+func (db *DynamoDBDatabase) Activity(locale *Locale, start string, count int, filter func(a Activity) bool) ([]Activity, string, error) {
 	var activity []Activity
 
 	var startKey map[string]dynamodb.AttributeValue
@@ -120,7 +120,7 @@ func (db *DynamoDBDatabase) Activity(locale *Locale, start string, count int) ([
 		for _, item := range result.Items {
 			if a, err := unmarshalActivity(item["rk"].B, item["v"].B); err != nil {
 				return nil, "", err
-			} else if a != nil {
+			} else if a != nil && filter(a) {
 				activity = append(activity, a)
 			}
 		}

--- a/server/index_handler.go
+++ b/server/index_handler.go
@@ -43,6 +43,7 @@ var index = `<!DOCTYPE html><html>
 		</div>
         <div class="content-box">
             <h1>{{call $.Translate "Activity"}}</h1>
+			<div id="help-toggle"></div>
             <a href="rss"><img src="static/images/rss-icon-28.png" class="rss-icon" /></a>
             <table id="activity-table" class="list">
                 <thead>

--- a/server/index_handler.go
+++ b/server/index_handler.go
@@ -43,7 +43,7 @@ var index = `<!DOCTYPE html><html>
 		</div>
         <div class="content-box">
             <h1>{{call $.Translate "Activity"}}</h1>
-			<div id="help-toggle"></div>
+            <div id="help-toggle"></div>
             <a href="rss"><img src="static/images/rss-icon-28.png" class="rss-icon" /></a>
             <table id="activity-table" class="list">
                 <thead>
@@ -59,7 +59,7 @@ var index = `<!DOCTYPE html><html>
                 <tbody>
                 </tbody>
             </table>
-            <div id="activity-nav"></div>
+            <div id="activity-nav" class="right"></div>
         </div>
         <footer>
             <p>This site is not affiliated with Path of Exile or Grinding Gear Games in any way.</p>

--- a/server/index_handler.go
+++ b/server/index_handler.go
@@ -58,7 +58,7 @@ var index = `<!DOCTYPE html><html>
                 <tbody>
                 </tbody>
             </table>
-            <div id="activity-nav" class="right"></div>
+            <div id="activity-nav"></div>
         </div>
         <footer>
             <p>This site is not affiliated with Path of Exile or Grinding Gear Games in any way.</p>

--- a/server/localization.go
+++ b/server/localization.go
@@ -17,6 +17,7 @@ type Locale struct {
 	IncludeReddit bool
 	Translations  map[string]string
 	ParseTime     func(s string, tz *time.Location) (time.Time, error)
+	HelpForumId   int
 
 	forumIds atomic.Value
 }
@@ -95,6 +96,7 @@ var Locales = []*Locale{
 	{
 		IncludeReddit: true,
 		Image:         "static/images/locales/gb.png",
+		HelpForumId:   584,
 	},
 	{
 		Subdomain: "br",
@@ -106,6 +108,7 @@ var Locales = []*Locale{
 			"Time":     "Hora",
 			"Forum":    "Fórum",
 		},
+		HelpForumId: 774,
 	},
 	{
 		Subdomain: "ru",
@@ -119,8 +122,9 @@ var Locales = []*Locale{
 		},
 	},
 	{
-		Subdomain: "th",
-		Image:     "static/images/locales/th.png",
+		Subdomain:   "th",
+		Image:       "static/images/locales/th.png",
+		HelpForumId: 1011,
 	},
 	{
 		Subdomain: "de",
@@ -132,6 +136,7 @@ var Locales = []*Locale{
 			"Time":     "Datum",
 			"Forum":    "Forum",
 		},
+		HelpForumId: 1123,
 	},
 	{
 		Subdomain: "fr",
@@ -143,6 +148,7 @@ var Locales = []*Locale{
 			"Time":     "Date",
 			"Forum":    "Forum",
 		},
+		HelpForumId: 1051,
 	},
 	{
 		Subdomain: "es",
@@ -154,6 +160,7 @@ var Locales = []*Locale{
 			"Time":     "Fecha",
 			"Forum":    "Foro",
 		},
+		HelpForumId: 1193,
 	},
 	{
 		Subdomain: "jp",

--- a/server/rss_handler.go
+++ b/server/rss_handler.go
@@ -43,7 +43,7 @@ type rssResponse struct {
 
 func RSSHandler(db Database) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		activity, _, err := db.Activity(LocaleForRequest(c.Request()), c.QueryParam("next"), 50)
+		activity, _, err := db.Activity(LocaleForRequest(c.Request()), c.QueryParam("next"), 50, func(a Activity) bool { return true })
 		if err != nil {
 			return err
 		}

--- a/server/static/index.js
+++ b/server/static/index.js
@@ -137,8 +137,6 @@ function loadActivity() {
             $tbody.append($tr);
         }
 
-        var activityNav = $('#activity-nav').empty();
-
         var nohelpText;
         var nohelpHref;
         if (nohelp != 'true') {
@@ -148,12 +146,12 @@ function loadActivity() {
             nohelpText = 'Show Help Forum';
             nohelpHref = '#page=' + page + '&nohelp=false';
         }
-        activityNav.append($('<a>').text(nohelpText).attr('href', nohelpHref).click(function() {
+        $('#help-toggle').empty().append($('<a>').text(nohelpText).attr('href', nohelpHref).click(function() {
             currentPage = undefined;
             window.scrollTo(0, 0);
         }));
 
-        activityNav.append($('<a>').text('Next Page').attr('href', '#page=' + data.next + '&nohelp=' + nohelp).click(function() {
+        $('#activity-nav').empty().append($('<a>').text('Next Page').attr('href', '#page=' + data.next + '&nohelp=' + nohelp).click(function() {
             window.scrollTo(0, 0);
         }));
     }).fail(function() {

--- a/server/static/index.js
+++ b/server/static/index.js
@@ -25,6 +25,10 @@ function loadActivity() {
     var previousPage = currentPage;
     currentPage = page;
 
+    if (nohelp == 'true') {
+        $('#activity-table tbody').empty().append($('<tr>').append($('<td>').attr('colspan', 6).text('Loading...')))
+    }
+
     $.get('activity.json?next=' + page + '&nohelp=' + nohelp, function(data) {
         var $tbody = $('#activity-table tbody');
         $tbody.empty();

--- a/server/static/index.js
+++ b/server/static/index.js
@@ -16,14 +16,16 @@ var POE = {
 };
 
 function loadActivity() {
-    var page = location.hash.replace(/^#page=/, '');
+    var params = new URLSearchParams(location.hash.replace(/^#/, ''));
+    var page = params.get('page') || '';
+    var nohelp = params.get('nohelp') || '';
     if (currentPage !== undefined && page == currentPage) {
         return;
     }
     var previousPage = currentPage;
     currentPage = page;
 
-    $.get('activity.json?next=' + page, function(data) {
+    $.get('activity.json?next=' + page + '&nohelp=' + nohelp, function(data) {
         var $tbody = $('#activity-table tbody');
         $tbody.empty();
 
@@ -135,7 +137,23 @@ function loadActivity() {
             $tbody.append($tr);
         }
 
-        $('#activity-nav').empty().append($('<a>').text('Next Page').attr('href', '#page=' + data.next).click(function() {
+        var activityNav = $('#activity-nav').empty();
+
+        var nohelpText;
+        var nohelpHref;
+        if (nohelp != 'true') {
+            nohelpText = 'Hide Help Forum';
+            nohelpHref = '#page=' + page + '&nohelp=true';
+        } else {
+            nohelpText = 'Show Help Forum';
+            nohelpHref = '#page=' + page + '&nohelp=false';
+        }
+        activityNav.append($('<a>').text(nohelpText).attr('href', nohelpHref).click(function() {
+            currentPage = undefined;
+            window.scrollTo(0, 0);
+        }));
+
+        activityNav.append($('<a>').text('Next Page').attr('href', '#page=' + data.next + '&nohelp=' + nohelp).click(function() {
             window.scrollTo(0, 0);
         }));
     }).fail(function() {

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -65,7 +65,10 @@ div.notice {
 	color: #202020;
 }
 
-div.notice a, div.notice a:visited, div.notice a:active, div.notice a:hover {
+div.notice a,
+div.notice a:visited,
+div.notice a:active,
+div.notice a:hover {
 	color: #202020;
 	text-decoration: underline;
 }
@@ -98,6 +101,12 @@ div.container {
 
 .rss-icon:hover {
 	opacity: 1.0;
+}
+
+#help-toggle {
+	position: absolute;
+	top: 24px;
+	right: 50px;
 }
 
 div.content-box h1 {
@@ -197,7 +206,8 @@ td.toggle img {
 	filter: opacity(70%);
 }
 
-.expander:hover, .collapser:hover {
+.expander:hover,
+.collapser:hover {
 	filter: opacity(100%);
 }
 
@@ -258,7 +268,8 @@ td.body img {
 	background-color: #323232;
 }
 
-.spoilerTitle, .spoilerContent {
+.spoilerTitle,
+.spoilerContent {
 	padding: 8px;
 }
 

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -48,9 +48,8 @@ td {
 	border-bottom: 1px solid #363636;
 }
 
-#activity-nav {
-	display: flex;
-	justify-content: space-between;
+.right {
+	text-align: right;
 }
 
 div.notice {
@@ -65,10 +64,7 @@ div.notice {
 	color: #202020;
 }
 
-div.notice a,
-div.notice a:visited,
-div.notice a:active,
-div.notice a:hover {
+div.notice a, div.notice a:visited, div.notice a:active, div.notice a:hover {
 	color: #202020;
 	text-decoration: underline;
 }
@@ -206,8 +202,7 @@ td.toggle img {
 	filter: opacity(70%);
 }
 
-.expander:hover,
-.collapser:hover {
+.expander:hover, .collapser:hover {
 	filter: opacity(100%);
 }
 
@@ -268,8 +263,7 @@ td.body img {
 	background-color: #323232;
 }
 
-.spoilerTitle,
-.spoilerContent {
+.spoilerTitle, .spoilerContent {
 	padding: 8px;
 }
 

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -48,8 +48,9 @@ td {
 	border-bottom: 1px solid #363636;
 }
 
-.right {
-	text-align: right;
+#activity-nav {
+	display: flex;
+	justify-content: space-between;
 }
 
 div.notice {


### PR DESCRIPTION
Fixes #138 :)

My Go and Javascript are both very out of practice, so apologies on that front!

This adds simple server-side filtering of posts to the "Help and Information" forum, selected by locale.  The RU and JP locales didn't seem to have a direct equivalent for that forum so I've left those unset, which means clicking on the toggle will be a no-op for those.

This will incur more db fetches per page load, unfortunately.  That might be avoidable in the DynamoDB backend if more metadata is stored along with the gzipped blob so the query can directly filter on properties like forum ID, but that would be a _much_ more invasive change and didn't seem proportionate to the feature scope.

I added the toggle link opposite the "Next Page" link at page bottom but UX is absolutely not my strong suit so I don't know if that's actually a good place for it :)